### PR TITLE
Extract method for ParallelPersistor worker loop

### DIFF
--- a/csharp/CSharpBencher/ParallelPersistor.cs
+++ b/csharp/CSharpBencher/ParallelPersistor.cs
@@ -58,8 +58,8 @@ namespace CSharpBencher
                 PendingInsert pendingInsert = null;
                 try
                 {
-                    pendingInsert = await _insertionQueue.ReceiveAsync();
-                    var rowSet = await _session.ExecuteAsync(pendingInsert.Statement);
+                    pendingInsert = await _insertionQueue.ReceiveAsync().ConfigureAwait(false);
+                    var rowSet = await _session.ExecuteAsync(pendingInsert.Statement).ConfigureAwait(false);
 
                     pendingInsert.Completion.SetResult(rowSet);
                 }


### PR DESCRIPTION
I do not understand why the worker loop is inside a long running task. Because the loop is starting with `await _insertionQueue.ReceiveAsync()`, the initial task is going to end almost instantly.
